### PR TITLE
[REFINE]: Remove href prop from news component

### DIFF
--- a/components/news.tsx
+++ b/components/news.tsx
@@ -17,7 +17,6 @@ const News = () => {
             description={news[0].description}
             header={news[0].header}
             icon={news[0].icon}
-            href={news[0].href}
             className='row-span-1 md:row-span-3'
           />
 
@@ -27,7 +26,6 @@ const News = () => {
               title={item.title}
               description={item.description}
               icon={item.icon}
-              href={item.href}
               className={index === 2 ? 'col-start-auto md:col-start-2' : ''}
             />
           ))}


### PR DESCRIPTION
- Removed the `href` prop from the first news item and the mapped news items to streamline the component and improve clarity.