### PR TITLE
[UPDATE]: Set default href value in Warning component

### DIFF
--- a/components/ui/warning.tsx
+++ b/components/ui/warning.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const Warning = ({
   children,
-  href,
+  href = '/',
 }: {
   children?: string | React.ReactNode;
   href?: string;


### PR DESCRIPTION
- Added a default value of '/' for the `href` prop in the Warning component to ensure a fallback link is available when not provided.